### PR TITLE
Improve batch deletion

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -92,9 +92,7 @@ class Shrine
       end
 
       def clear!
-        ids = []
-
-        storage_api.fetch_all do |token, s|
+        all_objects = storage_api.fetch_all do |token, s|
           prefix = "#{@prefix}/" if @prefix
           s.list_objects(
             @bucket,
@@ -102,18 +100,11 @@ class Shrine
             fields: "items/name",
             page_token: token,
           )
-        end.each do |object|
-          ids << object.name
-
-          if ids.size >= 100
-            # Batches are limited to 100, so we execute it and reset the ids
-            batch_delete(ids)
-            ids = []
-          end
         end
 
-        # We delete the remaining ones
-        batch_delete(ids) unless ids.empty?
+        all_objects.each_slice(100) do |objects|
+          batch_delete(objects.map(&:name))
+        end
       end
 
       def presign(id, **options)

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -102,9 +102,7 @@ class Shrine
           )
         end
 
-        all_objects.each_slice(100) do |objects|
-          batch_delete(objects.map(&:name))
-        end
+        batch_delete(all_objects.lazy.map(&:name))
       end
 
       def presign(id, **options)
@@ -143,9 +141,12 @@ class Shrine
       end
 
       def batch_delete(object_names)
-        storage_api.batch do |storage|
-          object_names.each do |name|
-            storage.delete_object(@bucket, name)
+        # Batches are limited to 100 operations
+        object_names.each_slice(100) do |names|
+          storage_api.batch do |storage|
+            names.each do |name|
+              storage.delete_object(@bucket, name)
+            end
           end
         end
       end


### PR DESCRIPTION
Batch deletion can be simplified with `Enumerable#each_slice`. We also move the batching into `#batch_delete`, so that it's applied to `#multi_delete` as well.