### PR TITLE
Add ability to set acl and object_options per upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@ Shrine.storages = {
 }
 ```
 
-You can set a predefined ACL on created objects, as well as custom headers using the `object_options` parameter:
+You can set a predefined ACL on created objects, as well as custom headers:
 
 ```rb
 Shrine::Storage::GoogleCloudStorage.new(
   bucket: "store",
-  default_acl: 'publicRead',
-  object_options: {
-    cache_control: 'public, max-age: 7200'
-  },
+  acl: 'publicRead',
+  cache_control: 'public, max-age: 7200'
 )
 ```
 

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -15,7 +15,7 @@ class Shrine
         @upload_options = upload_options
       end
 
-      def upload(io, id, shrine_metadata: {}, **upload_options)
+      def upload(io, id, shrine_metadata: {}, acl: @default_acl, **upload_options)
         # uploads `io` to the location `id`
 
         object = Google::Apis::StorageV1::Object.new merged_upload_options(id, upload_options)
@@ -26,7 +26,7 @@ class Shrine
             @bucket,
             object_name(id),
             object,
-            destination_predefined_acl: destination_acl(upload_options),
+            destination_predefined_acl: acl,
           )
         else
           storage_api.insert_object(
@@ -35,7 +35,7 @@ class Shrine
             content_type: shrine_metadata["mime_type"],
             upload_source: io.to_io,
             options: { uploadType: 'multipart' },
-            predefined_acl: destination_acl(upload_options),
+            predefined_acl: acl,
           )
         end
       end
@@ -160,10 +160,6 @@ class Shrine
           @storage_api = service
         end
         @storage_api
-      end
-
-      def destination_acl(upload_options)
-        upload_options[:acl] || @default_acl
       end
 
       def merged_upload_options(id, upload_options)

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -51,9 +51,9 @@ wXh0ExlzwgD2xJ0=
     Shrine::Storage::Linter.new(gcs(prefix: 'pre')).call(-> { image })
   end
 
-  describe "default_acl" do
+  describe "acl" do
     it "does set default acl when uploading a new object" do
-      gcs = gcs(default_acl: 'publicRead')
+      gcs = gcs(acl: 'publicRead')
       gcs.upload(image, 'foo')
 
       url = URI(gcs.url('foo'))
@@ -67,7 +67,7 @@ wXh0ExlzwgD2xJ0=
     end
 
     it "does set default acl when copying an object" do
-      gcs = gcs(default_acl: 'publicRead')
+      gcs = gcs(acl: 'publicRead')
       object = @uploader.upload(image, location: 'foo')
 
       gcs.upload(object, 'bar')
@@ -90,10 +90,10 @@ wXh0ExlzwgD2xJ0=
     end
   end
 
-  describe "object_options" do
-    it "does set the Cache-Control header when uploading a new object" do
+  describe "cache-control" do
+    it "sets the Cache-Control header when uploading a new object" do
       cache_control = 'public, max-age=7200'
-      gcs = gcs(default_acl: 'publicRead', object_options: { cache_control: cache_control })
+      gcs = gcs(acl: 'publicRead', cache_control: cache_control)
       gcs.upload(image, 'foo')
 
       assert @gcs.exists?('foo')
@@ -109,7 +109,7 @@ wXh0ExlzwgD2xJ0=
 
     it "does set the configured Cache-Control header when copying an object" do
       cache_control = 'public, max-age=7200'
-      gcs = gcs(default_acl: 'publicRead', object_options: { cache_control: cache_control })
+      gcs = gcs(acl: 'publicRead', cache_control: cache_control)
       object = @uploader.upload(image, location: 'foo')
 
       gcs.upload(object, 'bar')
@@ -125,9 +125,9 @@ wXh0ExlzwgD2xJ0=
     end
   end
 
-  describe "upload_options" do
-    it "overrides default_acl" do
-      gcs = gcs(default_acl: 'private')
+  describe "upload" do
+    it "overrides default acl" do
+      gcs = gcs(acl: 'private')
       upload_options = { acl: "publicRead" }
       gcs.upload(image, 'foo', shrine_metadata: {}, **upload_options)
 
@@ -141,13 +141,13 @@ wXh0ExlzwgD2xJ0=
       assert @gcs.exists?('foo')
     end
 
-    it "overrides object_options' Cache-Control" do
-      gcs = gcs(default_acl: 'private')
+    it "overrides Cache-Control" do
+      gcs = gcs(acl: 'private')
       cache_control = 'public, max-age=7200'
       gcs.upload(image,
                  'foo',
                  shrine_metadata: {},
-                 acl: 'publicRead', object_options: { cache_control: cache_control })
+                 acl: 'publicRead', cache_control: cache_control)
 
       assert @gcs.exists?('foo')
 


### PR DESCRIPTION
This builds on Shrine’s `upload_options` plugin as further described here:
https://github.com/janko-m/shrine/blob/864528eac0c3182f6c553b227535901d69b682c6/lib/shrine/plugins/upload_options.rb

Allowing the following:

```ruby
class ImageUploader < Shrine
  plugin :validation_helpers
  plugin :upload_options, store: {
    acl: "publicRead",
    object_options: { cache_control: 'public, max-age: 7200' }
  }
  ...
```

ACL can now be set per uploader or even per upload with a block:

```ruby
class PredictionUploader < Shrine
  plugin :validation_helpers
  plugin :upload_options, store: -> (io,context) do
    # do something
  end

```