### PR TITLE
Fix object content_type when moving from objects

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -18,7 +18,11 @@ class Shrine
       def upload(io, id, shrine_metadata: {}, **_options)
         # uploads `io` to the location `id`
 
-        object = Google::Apis::StorageV1::Object.new @object_options.merge(bucket: @bucket, name: object_name(id))
+        object = Google::Apis::StorageV1::Object.new @object_options.merge(
+          bucket: @bucket,
+          name: object_name(id),
+          content_type: shrine_metadata["mime_type"],
+        )
 
         if copyable?(io)
           storage_api.copy_object(


### PR DESCRIPTION
We would think that when copying object via the google storage api v1
the object's content_type would be retained, but this is not the case.

**Bug:**

When we insert a new object into the bucket, for example, when uploading
a new file to the "cache", we use the `storage_api.insert_object`
method, and we pass it a "content_type" option, and it creates a new file
w/ that content_type.

But when we copy this file via the `storage_api.copy_object` method,
which does not accept a "content_type" option, it does not inherit the object's
content_type.

**Solution:**

In this case, we need to initiate the Google::Apis::StorageV1::Object w/
its proper "content_type", if we want to copy the object w/ the correct
content_type.

Notes:

1) We still need to keep the "content_type" option when inserting an
object, or we will receive the following error:

```
invalid: Content-Type specified in the upload (application/octet-stream)
does not match Content-Type specified in metadata (image/png). If it was
a simple upload (uploadType=media), the Content-Type was specified as a
bare header. If it was a multipart upload (uploadType=multipart), then
the Content-Type was specified in the second part of the multipart. If
it was a resumable upload (uploadType=resumable), then the Content-Type
was specified with the X-Upload-Content-Type header with the start of
the resumable session. For more information, see
https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload.
```