### PR TITLE
Fix upload from Rails' ActionDispatch::Http::UploadedFile

### DIFF
--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -212,4 +212,38 @@ wXh0ExlzwgD2xJ0=
       assert_equal("https://123.mycdn.net/foo", url)
     end
   end
+
+  describe '#upload' do
+    it 'uploads a io stream to google cloud storage' do
+      io = StringIO.new("data")
+
+      file_key = random_key
+
+      @gcs.upload(io, file_key)
+
+      assert @gcs.exists?(file_key)
+    end
+
+    it 'uploads a non io object that responds to .to_io' do
+      io = StringIO.new("data")
+      file = FakeUploadedFile.new(io)
+
+      file_key = random_key
+
+      @gcs.upload(file, file_key)
+
+      assert @gcs.exists?(file_key)
+    end
+
+    it 'uploads a non io object that responds to .tempfile' do
+      io = StringIO.new("data")
+      file = FakeOldUploadedFile.new(io)
+
+      file_key = random_key
+
+      @gcs.upload(file, file_key)
+
+      assert @gcs.exists?(file_key)
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "dotenv"
 
 require "forwardable"
 require "stringio"
+require "securerandom"
 
 Dotenv.load!
 
@@ -23,6 +24,26 @@ class FakeIO
   delegate [:read, :size, :close, :eof?, :rewind] => :@io
 end
 
+class FakeUploadedFile
+  def initialize(io)
+    @io = io
+  end
+
+  def to_io
+    @io
+  end
+end
+
+class FakeOldUploadedFile
+  def initialize(io)
+    @io = io
+  end
+
+  def tempfile
+    @io
+  end
+end
+
 class Minitest::Test
   def fakeio(content = "file")
     FakeIO.new(content)
@@ -30,5 +51,9 @@ class Minitest::Test
 
   def image
     File.open("test/fixtures/image.jpg")
+  end
+
+  def random_key
+    SecureRandom.hex(32)
   end
 end


### PR DESCRIPTION
Fixes file uploads from Rails, where Shrine passes
ActionDispatch::Http::UploadedFile as the io object.

Bug:

When we try to pass a instance of  `ActionDispatch::Http::UploadedFile`
as the "upload_source" to `bucket.create_file`, google-cloud-ruby client raises:

`Google::Apis::ClientError, 'Invalid upload source'`

It doesn't accept an instance of ActionDispatch::Http::UploadedFile as
an upload source, the only acceptable upload sources are:

IO, IOString and Tempfile.

Solution:

Rails allows us to convert ActionDispatch::Http::UploadedFile
objects to an IO by calling .to_io on them.

Older versions of Rails, such as Rails 3.2, doesn't yet have the
to_io method, in this case, we need to check for a tempfile.