### PR TITLE
Implement #open using Down::ChunkedIO

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -1,5 +1,6 @@
 require "shrine"
 require "google/cloud/storage"
+require "down/chunked_io"
 
 class Shrine
   module Storage
@@ -70,12 +71,25 @@ class Shrine
         tempfile.tap(&:open)
       end
 
-      # Download the remote file to an in-memory StringIO object
-      # @return [StringIO] object
+      # Opens the remote file and returns it as `Down::ChunkedIO` object.
+      # @return [Down::ChunkedIO] object
+      # @see https://github.com/janko-m/down#downchunkedio
       def open(id)
-        io = get_file(id).download
-        io.rewind
-        io
+        file = get_file(id)
+
+        # create enumerator which lazily yields chunks of downloaded content
+        chunks = Enumerator.new do |yielder|
+          # trick to get google client to stream the download
+          proc_io = ProcIO.new { |data| yielder << data }
+          file.download(proc_io)
+        end
+
+        # wrap chunks in an IO-like object which downloads when needed
+        Down::ChunkedIO.new(
+          chunks: chunks,
+          size:   file.size,
+          data:   { file: file }
+        )
       end
 
       # checks if the file exists on the storage
@@ -159,6 +173,20 @@ class Shrine
         bucket = get_bucket
         object_names.each do |name|
           bucket.file(name).delete
+        end
+      end
+
+      # This class provides a writable IO wrapper around a proc object, with
+      # #write simply calling the proc, which we can pass in as the destination
+      # IO for download.
+      class ProcIO
+        def initialize(&proc)
+          @proc = proc
+        end
+
+        def write(data)
+          @proc.call(data)
+          data.bytesize # match return value of other IO objects
         end
       end
     end

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -81,7 +81,7 @@ class Shrine
         chunks = Enumerator.new do |yielder|
           # trick to get google client to stream the download
           proc_io = ProcIO.new { |data| yielder << data }
-          file.download(proc_io)
+          file.download(proc_io, verify: :none)
         end
 
         # wrap chunks in an IO-like object which downloads when needed

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -188,6 +188,11 @@ class Shrine
           @proc.call(data)
           data.bytesize # match return value of other IO objects
         end
+
+        # TODO: Remove this once google/google-api-ruby-client#638 is merged.
+        def flush
+          # google-api-client calls this method
+        end
       end
     end
   end

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -258,4 +258,14 @@ wXh0ExlzwgD2xJ0=
       assert @gcs.exists?(file_key)
     end
   end
+
+  describe "#open" do
+    it "returns an IO-like object around the file content" do
+      gcs.upload(image, 'foo')
+      io = gcs.open('foo')
+      assert_equal(image.size, io.size)
+      assert_equal(image.read, io.read)
+      assert_instance_of(Google::Cloud::Storage::File, io.data[:file])
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,7 @@ class Minitest::Test
   end
 
   def image
-    File.open("test/fixtures/image.jpg")
+    File.open("test/fixtures/image.jpg", "rb")
   end
 
   def random_key


### PR DESCRIPTION
This will make the storage work well with the `restore_metadata` Shrine plugin, as it will allow extracting metadata of a remote file uploaded to GCS by downloading only a portion of the file content.

Closes #8