### PR TITLE
Fix presigned uploads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
     declarative (0.0.10)
     declarative-option (0.1.0)
     digest-crc (0.4.1)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
     down (4.2.0)
     faraday (0.13.1)
@@ -41,6 +43,15 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    http (3.0.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (>= 2.0.0.pre.pre2, < 3)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.0.0)
+    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     jwt (2.1.0)
     little-plugger (1.1.4)
@@ -70,12 +81,16 @@ GEM
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     uber (0.1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   dotenv
+  http (~> 3.0)
   minitest
   rake
   shrine-google_cloud_storage!

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -117,9 +117,15 @@ class Shrine
       end
 
       def presign(id, **options)
+        headers = {}
+        headers["Content-Type"] = options[:content_type] if options[:content_type]
+        headers["Content-MD5"]  = options[:content_md5] if options[:content_md5]
+        headers.merge!(options[:headers]) if options[:headers]
+
         OpenStruct.new(
           url: storage.signed_url(@bucket, object_name(id), options),
           fields: {},
+          headers: headers
         )
       end
 

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -51,13 +51,10 @@ class Shrine
 
       # URL to the remote file, accepts options for customizing the URL
       def url(id, **options)
-        if(options.key? :expires)
-          signed_url = presign(id, options).url
-          if @host.nil?
-            signed_url
-          else
-            signed_url.gsub(/storage.googleapis.com\/#{@bucket}/, @host)
-          end
+        if options.key? :expires
+          signed_url = storage.signed_url(@bucket, object_name(id), options)
+          signed_url.gsub!(/storage.googleapis.com\/#{@bucket}/, @host) if @host
+          signed_url
         else
           host = @host || "storage.googleapis.com/#{@bucket}"
           "https://#{host}/#{object_name(id)}"

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -123,7 +123,7 @@ class Shrine
         headers.merge!(options[:headers]) if options[:headers]
 
         OpenStruct.new(
-          url: storage.signed_url(@bucket, object_name(id), options),
+          url: storage.signed_url(@bucket, object_name(id), method: "PUT", **options),
           fields: {},
           headers: headers
         )

--- a/shrine-google_cloud_storage.gemspec
+++ b/shrine-google_cloud_storage.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "dotenv"
+  gem.add_development_dependency "http", "~> 3.0"
 end

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -191,6 +191,8 @@ wXh0ExlzwgD2xJ0=
       # upload succeeds
       response = HTTP.headers(presign.headers).put(presign.url, body: content)
       assert_equal 200, response.code
+
+      assert_equal content, HTTP.get(gcs.url('foo', expires: 60)).to_s
     end
   end
 

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -119,7 +119,7 @@ wXh0ExlzwgD2xJ0=
   end
 
   describe "#presign" do
-    it "signs a GET url with a signing key and issuer" do
+    it "signs a PUT url with a signing key and issuer" do
       gcs = gcs()
       gcs.upload(image, 'foo')
 
@@ -151,7 +151,7 @@ wXh0ExlzwgD2xJ0=
       end
     end
 
-    it "signs a GET url with discovered credentials" do
+    it "signs a PUT url with discovered credentials" do
       gcs = gcs()
       gcs.upload(image, 'foo')
 
@@ -187,6 +187,10 @@ wXh0ExlzwgD2xJ0=
       }
 
       assert_equal expected_headers, presign.headers
+
+      # upload succeeds
+      response = HTTP.headers(presign.headers).put(presign.url, body: content)
+      assert_equal 200, response.code
     end
   end
 

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -181,6 +181,31 @@ wXh0ExlzwgD2xJ0=
         assert_equal({}, presign.fields)
       end
     end
+
+    it "adds headers for header parameters" do
+      gcs = gcs()
+
+      content = "text"
+      md5     = Digest::MD5.base64digest(content)
+
+      presign = gcs.presign('foo',
+        content_type: 'text/plain',
+        content_md5: md5,
+        headers: {
+          'x-goog-acl' => 'private',
+          'x-goog-meta-foo' => 'bar,baz'
+        },
+      )
+
+      expected_headers = {
+        'Content-Type'    => 'text/plain',
+        'Content-MD5'     => md5,
+        'x-goog-acl'      => 'private',
+        'x-goog-meta-foo' => 'bar,baz',
+      }
+
+      assert_equal expected_headers, presign.headers
+    end
   end
 
   describe "#url" do

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "shrine/storage/linter"
 require "date"
-require "net/https"
+require "http"
 
 describe Shrine::Storage::GoogleCloudStorage do
   def gcs(options = {})
@@ -56,12 +56,8 @@ wXh0ExlzwgD2xJ0=
       gcs = gcs(default_acl: 'publicRead')
       gcs.upload(image, 'foo')
 
-      url = URI(gcs.url('foo'))
-      Net::HTTP.start(url.host, url.port, use_ssl: true) do |http|
-        response = http.head(url.path)
-
-        assert_equal "200", response.code
-      end
+      response = HTTP.head(gcs.url('foo'))
+      assert_equal 200, response.code
 
       assert @gcs.exists?('foo')
     end
@@ -73,18 +69,12 @@ wXh0ExlzwgD2xJ0=
       gcs.upload(object, 'bar')
 
       # foo needs to not be readable
-      url_foo = URI(gcs.url('foo'))
-      Net::HTTP.start(url_foo.host, url_foo.port, use_ssl: true) do |http|
-        response = http.head(url_foo.path)
-        assert_equal "403", response.code
-      end
+      response = HTTP.head(gcs.url('foo'))
+      assert_equal 403, response.code
 
       # bar needs to be readable
-      url_bar = URI(gcs.url('bar'))
-      Net::HTTP.start(url_bar.host, url_bar.port, use_ssl: true) do |http|
-        response = http.head(url_bar.path)
-        assert_equal "200", response.code
-      end
+      response = HTTP.head(gcs.url('bar'))
+      assert_equal 200, response.code
 
       assert @gcs.exists?('foo')
     end
@@ -98,13 +88,9 @@ wXh0ExlzwgD2xJ0=
 
       assert @gcs.exists?('foo')
 
-      url = URI(gcs.url('foo'))
-      Net::HTTP.start(url.host, url.port, use_ssl: true) do |http|
-        response = http.head(url.path)
-        assert_equal "200", response.code
-        assert_equal 1, response.get_fields('Cache-Control').size
-        assert_equal cache_control, response.get_fields('Cache-Control')[0]
-      end
+      response = HTTP.head(gcs.url('foo'))
+      assert_equal 200, response.code
+      assert_equal cache_control, response.headers["Cache-Control"]
     end
 
     it "does set the configured Cache-Control header when copying an object" do
@@ -115,13 +101,9 @@ wXh0ExlzwgD2xJ0=
       gcs.upload(object, 'bar')
 
       # bar needs to have the correct Cache-Control header
-      url_bar = URI(gcs.url('bar'))
-      Net::HTTP.start(url_bar.host, url_bar.port, use_ssl: true) do |http|
-        response = http.head(url_bar.path)
-        assert_equal "200", response.code
-        assert_equal 1, response.get_fields('Cache-Control').size
-        assert_equal cache_control, response.get_fields('Cache-Control')[0]
-      end
+      response = HTTP.head(gcs.url('bar'))
+      assert_equal 200, response.code
+      assert_equal cache_control, response.headers["Cache-Control"]
     end
   end
 


### PR DESCRIPTION
Shrine's presign endpoint returns URL, fields and headers that the client (browser) needs to upload to. The `Shrine::Storage::GoogleCloudStorage#presign` method, which the presign endpoint calls, never returns any headers, which means that the presign endpoint always returns `"headers": {}` in the response. When the browser then tries to upload the file to the URL, but because the request headers required by GCS weren't included, the upload fails.

The solution is for `Shrine::Storage::GoogleCloudStorage#presign` to return appropriate headers when either `:content_type`, `content_md5` or `headers` options were given, which will make the presign endpoint automatically return them, and then the client (browser) can then include them in the upload request.

I also updated the `:method` to be `PUT` (the default is `GET`), because presigned URLs are meant for *uploading*, not downloading. Uploading doesn't work if `method: "PUT"` is not specified.

Btw, I also switched from Net::HTTP to HTTP.rb, because Net::HTTP has a really horrible API :stuck_out_tongue:, while HTTP.rb has a really nice and intuitive API.

Fixes #22