### PR TITLE
Update #presign for latest Shrine

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -113,17 +113,16 @@ class Shrine
         end
       end
 
+      # returns request data (:method, :url, and :headers) for direct uploads
       def presign(id, **options)
+        url = storage.signed_url(@bucket, object_name(id), method: "PUT", **options)
+
         headers = {}
         headers["Content-Type"] = options[:content_type] if options[:content_type]
         headers["Content-MD5"]  = options[:content_md5] if options[:content_md5]
         headers.merge!(options[:headers]) if options[:headers]
 
-        OpenStruct.new(
-          url: storage.signed_url(@bucket, object_name(id), method: "PUT", **options),
-          fields: {},
-          headers: headers
-        )
+        { method: :put, url: url, headers: headers }
       end
 
       def object_name(id)

--- a/shrine-google_cloud_storage.gemspec
+++ b/shrine-google_cloud_storage.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.files        = Dir["README.md", "LICENSE.txt", "lib/**/*.rb", "shrine-google_cloud_storage.gemspec"]
   gem.require_path = "lib"
 
-  gem.add_dependency "shrine", "~> 2.0"
+  gem.add_dependency "shrine", "~> 2.11"
   gem.add_dependency "google-cloud-storage", "~> 1.6"
 
   gem.add_development_dependency "rake"

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -131,11 +131,12 @@ wXh0ExlzwgD2xJ0=
           issuer: sa[:client_email],
         )
 
-        assert presign.url.start_with? "https://storage.googleapis.com/#{gcs.bucket}/foo?"
-        assert presign.url.include? "Expires=1486650200"
-        assert presign.url.include? "GoogleAccessId=test-shrine%40test.google"
-        assert presign.url.include? "Signature=" # each tester's discovered signature will be different
-        assert_equal({}, presign.fields)
+        assert_equal :put, presign[:method]
+        assert presign[:url].start_with? "https://storage.googleapis.com/#{gcs.bucket}/foo?"
+        assert presign[:url].include? "Expires=1486650200"
+        assert presign[:url].include? "GoogleAccessId=test-shrine%40test.google"
+        assert presign[:url].include? "Signature=" # each tester's discovered signature will be different
+        assert_equal({}, presign[:headers])
       end
     end
 
@@ -144,10 +145,11 @@ wXh0ExlzwgD2xJ0=
 
       Time.stub :now, Time.at(1486649900) do
         presign = gcs.presign('nonexisting')
-        assert presign.url.include? "https://storage.googleapis.com/#{gcs.bucket}/nonexisting?"
-        assert presign.url.include? "Expires=1486650200"
-        assert presign.url.include? "Signature=" # each tester's discovered signature will be different
-        assert_equal({}, presign.fields)
+        assert_equal :put, presign[:method]
+        assert presign[:url].include? "https://storage.googleapis.com/#{gcs.bucket}/nonexisting?"
+        assert presign[:url].include? "Expires=1486650200"
+        assert presign[:url].include? "Signature=" # each tester's discovered signature will be different
+        assert_equal({}, presign[:headers])
       end
     end
 
@@ -157,10 +159,11 @@ wXh0ExlzwgD2xJ0=
 
       Time.stub :now, Time.at(1486649900) do
         presign = gcs.presign('foo')
-        assert presign.url.include? "https://storage.googleapis.com/#{gcs.bucket}/foo?"
-        assert presign.url.include? "Expires=1486650200"
-        assert presign.url.include? "Signature=" # each tester's discovered signature will be different
-        assert_equal({}, presign.fields)
+        assert_equal :put, presign[:method]
+        assert presign[:url].include? "https://storage.googleapis.com/#{gcs.bucket}/foo?"
+        assert presign[:url].include? "Expires=1486650200"
+        assert presign[:url].include? "Signature=" # each tester's discovered signature will be different
+        assert_equal({}, presign[:headers])
       end
     end
 
@@ -186,10 +189,10 @@ wXh0ExlzwgD2xJ0=
         'x-goog-meta-foo' => 'bar,baz',
       }
 
-      assert_equal expected_headers, presign.headers
+      assert_equal expected_headers, presign[:headers]
 
       # upload succeeds
-      response = HTTP.headers(presign.headers).put(presign.url, body: content)
+      response = HTTP.headers(presign[:headers]).put(presign[:url], body: content)
       assert_equal 200, response.code
 
       assert_equal content, HTTP.get(gcs.url('foo', expires: 60)).to_s


### PR DESCRIPTION
Shrine 2.11+ allows `#presign` to return a simple Hash, so we can stop using `OpenStruct` (I personally like switching to a simple Hash). Also, it's now recommended to include :method as well, so that the client knows which HTTP verb it should use for the upload request.

This change should make shrine-google_cloud_storage work with Uppy's [AwsS3](https://uppy.io/docs/aws-s3/) plugin, as without `:method` it assumes it needs to make a POST request, which will not work.

This will be a breaking change for anyone using `#presign` directly, so if you're not comfortable with this change, we can keep using `OpenStruct` and just add `:method` to it. In Shrine 3 presign objects will only need to be *convertable* to Hash, and luckily both `OpenStruct` and `Struct` implement `#to_h` to convert them to a Hash.