### PR TITLE
Fix #clear! potentially not deleting past 2nd page

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -106,10 +106,9 @@ class Shrine
       def clear!
         prefix = "#{@prefix}/" if @prefix
         files = get_bucket.files prefix: prefix
-        batch_delete(files.lazy.map(&:name))
         loop do
-          break if !files.next?
-          batch_delete(files.next.lazy.map(&:name))
+          batch_delete(files.lazy.map(&:name))
+          files = files.next or break
         end
       end
 


### PR DESCRIPTION
`Google::Cloud::Storage::File::List#next` doesn't appear to modify the current list, it just returns a new list. But even if that wasn't the case, that functionality might be removed in the future as it's not documented.

So we switch to using the return value of `#next`, as is documented.