### PR TITLE
Correctly ensure input IO is a file in #upload

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -38,7 +38,7 @@ class Shrine
           end
           file
         else
-          Shrine.with_file(io) do |file|
+          with_file(io) do |file|
               get_bucket.create_file(
                   file,
                   object_name(id), # path
@@ -155,6 +155,14 @@ class Shrine
         io.is_a?(UploadedFile) &&
           io.storage.is_a?(Storage::GoogleCloudStorage)
         # TODO: add a check for the credentials
+      end
+
+      def with_file(io)
+        if io.respond_to?(:tempfile) # ActionDispatch::Http::UploadedFile
+          yield tempfile
+        else
+          Shrine.with_file(io) { |file| yield file }
+        end
       end
 
       def batch_delete(object_names)

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -38,14 +38,16 @@ class Shrine
           end
           file
         else
-          get_bucket.create_file(
-              prepare_io(io), # file -  IO object, or IO-ish object like StringIO
-              object_name(id), # path
-              @object_options.merge(
-                  content_type: shrine_metadata["mime_type"],
-                  acl: @default_acl
-              ).merge(options)
-          )
+          Shrine.with_file(io) do |file|
+              get_bucket.create_file(
+                  file,
+                  object_name(id), # path
+                  @object_options.merge(
+                      content_type: shrine_metadata["mime_type"],
+                      acl: @default_acl
+                  ).merge(options)
+              )
+          end
         end
       end
 
@@ -153,23 +155,6 @@ class Shrine
         io.is_a?(UploadedFile) &&
           io.storage.is_a?(Storage::GoogleCloudStorage)
         # TODO: add a check for the credentials
-      end
-
-      # Google cloud storage client only accepts IO|IOString|Tempfile instances
-      # or else it will raise a "Google::Apis::ClientError, 'Invalid upload source"
-      #
-      # We need to convert our file to an IO.
-      j
-      # see:
-      # https://github.com/google/google-api-ruby-client/blob/1c2cf5d57fd5e606c03f2aecab88469f46b8f3b2/lib/google/apis/core/upload.rb#L77
-      def prepare_io(io)
-        if io.respond_to?(:to_io)
-          io.to_io
-        elsif io.respond_to?(:tempfile)
-          io.tempfile
-        else
-          io
-        end
       end
 
       def batch_delete(object_names)

--- a/shrine-google_cloud_storage.gemspec
+++ b/shrine-google_cloud_storage.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.files        = Dir["README.md", "LICENSE.txt", "lib/**/*.rb", "shrine-google_cloud_storage.gemspec"]
   gem.require_path = "lib"
 
-  gem.add_dependency "shrine", "~> 2.0"
+  gem.add_dependency "shrine", "~> 2.11"
   gem.add_dependency "google-cloud-storage", "~> 1.6"
 
   gem.add_development_dependency "rake"

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -249,20 +249,9 @@ wXh0ExlzwgD2xJ0=
       assert @gcs.exists?(file_key)
     end
 
-    it 'uploads a non io object that responds to .to_io' do
+    it 'uploads Rails file objects' do
       io = StringIO.new("data")
-      file = FakeUploadedFile.new(io)
-
-      file_key = random_key
-
-      @gcs.upload(file, file_key)
-
-      assert @gcs.exists?(file_key)
-    end
-
-    it 'uploads a non io object that responds to .tempfile' do
-      io = StringIO.new("data")
-      file = FakeOldUploadedFile.new(io)
+      file = RailsFile.new(io)
 
       file_key = random_key
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,23 +24,17 @@ class FakeIO
   delegate [:read, :size, :close, :eof?, :rewind] => :@io
 end
 
-class FakeUploadedFile
-  def initialize(io)
-    @io = io
-  end
-
-  def to_io
-    @io
-  end
-end
-
-class FakeOldUploadedFile
+class RailsFile
   def initialize(io)
     @io = io
   end
 
   def tempfile
     @io
+  end
+
+  def path
+    @io.path
   end
 end
 


### PR DESCRIPTION
google-cloud-storage gem seems to accept only files, so we use `Shrine.with_file` that was added to Shrine 2.11, which, given an IO object, will copy its contents into a temporary file object and yield it to the block.