### PR TITLE
Add support for specifying credentials

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -156,7 +156,7 @@ class Shrine
         opts[:project] = @project if @project
         opts[:credentials] = @credentials if @credentials
 
-        @storage = Google::Cloud::Storage.new(project: @project)
+        @storage = Google::Cloud::Storage.new(opts)
       end
 
       def copyable?(io)

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -10,7 +10,7 @@ class Shrine
       # Initialize a Shrine::Storage for GCS allowing for auto-discovery of the Google::Cloud::Storage client.
       # @param [String] project Provide if not using auto discovery
       # @see http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.6.0/guides/authentication#environmentvariables for information on discovery
-      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {})
+      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {}, credentials: nil)
         @project = project
         @bucket = bucket
         @prefix = prefix
@@ -18,6 +18,7 @@ class Shrine
         @default_acl = default_acl
         @object_options = object_options
         @storage = nil
+        @credentials = credentials
       end
 
       # If the file is an UploadFile from GCS, issues a copy command, otherwise it uploads a file.
@@ -149,11 +150,13 @@ class Shrine
 
       # @see http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.6.0/guides/authentication
       def storage
-        @storage ||= if @project.nil?
-                       Google::Cloud::Storage.new
-                     else
-                       Google::Cloud::Storage.new(project: @project)
-                     end
+        return @storage if @storage
+
+        opts = {}
+        opts[:project] = @project if @project
+        opts[:credentials] = @credentials if @credentials
+
+        @storage = Google::Cloud::Storage.new(project: @project)
       end
 
       def copyable?(io)

--- a/test/create_test_environment.sh
+++ b/test/create_test_environment.sh
@@ -58,7 +58,13 @@ fi
 # Display every command executed from now
 set -x
 
-gcloud projects create $GOOGLE_CLOUD_PROJECT
+gcloud projects create $GOOGLE_CLOUD_PROJECT || read -p "Looks like this service accounts exists. If so, continue? (y/n)? " CONT
+
+if [ "$CONT" == "n" ]
+then
+  echo "Aborting!"
+  exit 3
+fi
 
 if [ $? -eq 1 ]
 then
@@ -73,7 +79,7 @@ gcloud beta billing projects link $GOOGLE_CLOUD_PROJECT --billing-account=$GOOGL
 
 gcloud iam service-accounts create $GCS_SA \
     --project=$GOOGLE_CLOUD_PROJECT \
-    --display-name $GCS_SA
+    --display-name $GCS_SA || true
 
 GCS_SA_EMAIL=$(gcloud iam service-accounts list \
     --project=$GOOGLE_CLOUD_PROJECT \

--- a/test/create_test_environment.sh
+++ b/test/create_test_environment.sh
@@ -58,13 +58,7 @@ fi
 # Display every command executed from now
 set -x
 
-gcloud projects create $GOOGLE_CLOUD_PROJECT || read -p "Looks like this service accounts exists. If so, continue? (y/n)? " CONT
-
-if [ "$CONT" == "n" ]
-then
-  echo "Aborting!"
-  exit 3
-fi
+gcloud projects create $GOOGLE_CLOUD_PROJECT
 
 if [ $? -eq 1 ]
 then
@@ -79,7 +73,7 @@ gcloud beta billing projects link $GOOGLE_CLOUD_PROJECT --billing-account=$GOOGL
 
 gcloud iam service-accounts create $GCS_SA \
     --project=$GOOGLE_CLOUD_PROJECT \
-    --display-name $GCS_SA || true
+    --display-name $GCS_SA
 
 GCS_SA_EMAIL=$(gcloud iam service-accounts list \
     --project=$GOOGLE_CLOUD_PROJECT \


### PR DESCRIPTION
This PR allows the `credentials` option to be specified for Storage. This way, we do not have to use global credentials.