### PR TITLE
Allow acl to be specified for an object upload

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -30,7 +30,7 @@ class Shrine
           file = existing_file.copy(
               @bucket, # dest_bucket_or_path - the bucket to copy the file to
               object_name(id), # dest_path - the path to copy the file to in the given bucket
-              acl: @default_acl
+              acl: options.fetch(:acl) { @default_acl }
           ) do |f|
             # Workaround a bug in File#copy where the content-type is not copied if you provide a block
             # See https://github.com/renchap/shrine-google_cloud_storage/issues/36
@@ -50,7 +50,7 @@ class Shrine
                   object_name(id), # path
                   @object_options.merge(
                       content_type: shrine_metadata["mime_type"],
-                      acl: @default_acl
+                      acl: options.fetch(:acl) { @default_acl }
                   ).merge(options)
               )
           end

--- a/test/gcs_test.rb
+++ b/test/gcs_test.rb
@@ -88,6 +88,18 @@ wXh0ExlzwgD2xJ0=
 
       assert @gcs.exists?(filename1)
     end
+
+    it "allows for the acl to be set on an object level" do
+      filename = generate_test_filename
+
+      gcs = gcs(default_acl: 'private')
+      gcs.upload(image, filename, acl: 'publicRead')
+
+      response = HTTP.head(gcs.url(filename))
+      assert_equal 200, response.code
+
+      assert @gcs.exists?(filename)
+    end
   end
 
   describe "object_options" do


### PR DESCRIPTION
This is useful for certain files which need to have different permissions. Currently, we maintain a monkey-patch which adds this, so I figured it could be worthwhile to upstream the functionality 😄 