### PR TITLE
Fix public urls for publicly accesible buckets and public url encoding

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -64,7 +64,7 @@ class Shrine
       def url(id, **options)
         if @public || @default_acl == 'publicRead'
           host = @host || "storage.googleapis.com/#{@bucket}"
-          "https://#{host}/#{URI.encode_www_form_component(object_name(id))}"
+          "https://#{host}/#{URI.encode_www_form_component(object_name(id)).gsub("+", "%20")}"
         else
           signed_url = storage.signed_url(@bucket, object_name(id), **options)
           signed_url.gsub!(/storage.googleapis.com\/#{@bucket}/, @host) if @host

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -10,7 +10,7 @@ class Shrine
       # Initialize a Shrine::Storage for GCS allowing for auto-discovery of the Google::Cloud::Storage client.
       # @param [String] project Provide if not using auto discovery
       # @see http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.6.0/guides/authentication#environmentvariables for information on discovery
-      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {}, credentials: nil)
+      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {}, credentials: nil, public: false)
         @project = project
         @bucket = bucket
         @prefix = prefix
@@ -19,6 +19,7 @@ class Shrine
         @object_options = object_options
         @storage = nil
         @credentials = credentials
+        @public = public
       end
 
       # If the file is an UploadFile from GCS, issues a copy command, otherwise it uploads a file.
@@ -61,7 +62,7 @@ class Shrine
 
       # URL to the remote file, accepts options for customizing the URL
       def url(id, **options)
-        if @default_acl == 'publicRead'
+        if @public || @default_acl == 'publicRead'
           host = @host || "storage.googleapis.com/#{@bucket}"
           "https://#{host}/#{URI.encode_www_form_component(object_name(id))}"
         else

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -64,7 +64,7 @@ class Shrine
       def url(id, **options)
         if @public || @default_acl == 'publicRead'
           host = @host || "storage.googleapis.com/#{@bucket}"
-          "https://#{host}/#{URI.encode_www_form_component(object_name(id)).gsub("+", "%20")}"
+          "https://#{host}/#{Addressable::URI.encode_component(object_name(id), Addressable::URI::CharacterClasses::PATH)}"
         else
           signed_url = storage.signed_url(@bucket, object_name(id), **options)
           signed_url.gsub!(/storage.googleapis.com\/#{@bucket}/, @host) if @host


### PR DESCRIPTION
First: Although I understand how it's a saner default to always generate signed keys, its current implementation breaks previously working storage buckets with `public_access` set as "Public to the internet".

Furthermore, the new code, that uses the `default_acl` option to determine whether a signed url should be generated or not, does not work if [uniform bucket level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) is enabled for that bucket, generating a `Google::Cloud::InvalidArgumentError (invalid: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled.` error message when trying to upload a file

Adding a new `public` parameter was the quickest solution I found to enforce public url generation without needing to set the default_acl parameter


Second, when the deprecated `URI.encode` was changed by the new `URI..encode_www_form_component`,  at https://github.com/renchap/shrine-google_cloud_storage/commit/099b233027ddc020b4c2a3b0c43bb7a28f095197, empty space characters were replaced by `+` instead of `%20`. GCS doesn't recognize this, sending a 404 error code when trying to access the object with that url.
The second commit adds a gsub solving that
