### PR TITLE
Add  option to support 'Requester Pays' buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `user_project` option on storage, which enables the `userProject` option on the underlying `google-cloud-storage` client, allowing to specify a project to bill for the request for requester-pays buckets (https://cloud.google.com/storage/docs/using-requester-pays)
+
 ## 3.3.0 - 2022-08-14
 
 ### Added

--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -10,7 +10,7 @@ class Shrine
       # Initialize a Shrine::Storage for GCS allowing for auto-discovery of the Google::Cloud::Storage client.
       # @param [String] project Provide if not using auto discovery
       # @see http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.6.0/guides/authentication#environmentvariables for information on discovery
-      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {}, credentials: nil, public: false)
+      def initialize(project: nil, bucket:, prefix: nil, host: nil, default_acl: nil, object_options: {}, credentials: nil, public: false, user_project: nil)
         @project = project
         @bucket = bucket
         @prefix = prefix
@@ -18,6 +18,7 @@ class Shrine
         @object_options = object_options
         @storage = nil
         @credentials = credentials
+        @user_project = user_project
 
         @default_acl = if public && default_acl && default_acl != "publicRead"
                          raise Shrine::Error, "You can not set both public and default_acl"
@@ -154,8 +155,8 @@ class Shrine
         get_bucket.file(object_name(id))
       end
 
-      def get_bucket(bucket_name = @bucket)
-        storage.bucket(bucket_name, skip_lookup: true)
+      def get_bucket(bucket_name = @bucket, user_project = @user_project)
+        storage.bucket(bucket_name, skip_lookup: true, user_project: user_project)
       end
 
       # @see http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.6.0/guides/authentication

--- a/shrine-google_cloud_storage.gemspec
+++ b/shrine-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = "shrine-google_cloud_storage"
-  gem.version       = "3.3.0"
+  gem.version       = "3.4.0"
 
   gem.required_ruby_version = ">= 2.6"
 


### PR DESCRIPTION
Closes #57 

GCS has an option on buckets to make them a "Requester Pays" type of bucket: https://cloud.google.com/storage/docs/requester-pays. In short, this allows tracing of who/what is actually requesting an upload/download.

To query a bucket where "requester pays" is enabled, the `userProject` needs to be added in the URL. The GCS Ruby library provides this as an optional `user_project` keyword argument to `Project#bucket`: https://github.com/googleapis/google-cloud-ruby/blob/7523214b3c64f88db5e96269b397b066abf4b92e/google-cloud-storage/lib/google/cloud/storage/project.rb#L208-L216

When this is not passed, an error is thrown when listing/uploading files in a requester-pays bucket: `Bucket is a requester pays bucket but no user project provided. (Google::Cloud::InvalidArgumentError)`

This MR adds support for "requester pays"-buckets by accepting a `user_project` parameter (defaults to `nil`) on the Storage initializer, which is then used when calling `Project#bucket`.